### PR TITLE
Retry interrupted syscalls

### DIFF
--- a/linuxdvb/demux/filter.go
+++ b/linuxdvb/demux/filter.go
@@ -80,9 +80,16 @@ func (s *syn) WaitRead(f *os.File) (bool, error) {
 	s.m.Lock()
 	for {
 		var r fdset
+		var n int
+		var err error
 		r.Set(ffd)
 		r.Set(pfd)
-		n, err := syscall.Select(nfd, r.Sys(), nil, nil, nil)
+		for {
+			n, err = syscall.Select(nfd, r.Sys(), nil, nil, nil)
+			if err != syscall.EINTR {
+				break
+			}
+		}
 		if err != nil {
 			return false, err
 		}

--- a/linuxdvb/frontend/api3.go
+++ b/linuxdvb/frontend/api3.go
@@ -494,9 +494,16 @@ func (f API3) WaitEvent(ev *Event, deadline time.Time) (bool, error) {
 			return true, nil
 		}
 		var r syscall.FdSet
+		var n int
+		var err error
 		r.Bits[fd/64] = 1 << (fd % 64)
 		tv := syscall.NsecToTimeval(int64(timeout))
-		n, err := syscall.Select(int(fd+1), &r, nil, nil, &tv)
+		for {
+			n, err = syscall.Select(int(fd+1), &r, nil, nil, &tv)
+			if err != syscall.EINTR {
+				break
+			}
+		}
 		if err != nil {
 			return false, Error{"get", "event (select)", err}
 		}

--- a/linuxdvb/frontend/api5.go
+++ b/linuxdvb/frontend/api5.go
@@ -14,7 +14,12 @@ type Device struct {
 }
 
 func Open(filepath string) (d Device, err error) {
-	d.file, err = os.OpenFile(filepath, os.O_RDWR, 0)
+	for {
+		d.file, err = os.OpenFile(filepath, os.O_RDWR, 0)
+		if err == nil || err.(*os.PathError).Err != syscall.EINTR {
+			break
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
This happens frequently since Go 1.14, see https://golang.org/doc/go1.14#runtime

open*() generally isn't interruptable but for device files it is.